### PR TITLE
Refining headers in the follwing files for faster execution

### DIFF
--- a/B+ Tree.cpp
+++ b/B+ Tree.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <fstream>
 #include <string>
-#include <filesystem>
+//#include <filesystem>
 #include "B+ Tree.h"
 
 #define _CRT_SECURE_NO_DEPRECATE  //for VS 2019

--- a/B+ Tree.h
+++ b/B+ Tree.h
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <fstream>
 #include <string>
-#include <filesystem>
+//#include <filesystem>
 using namespace std;
 
 #ifndef NODE_H

--- a/remove.cpp
+++ b/remove.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cstring>
 #include "B+ Tree.h"
 
 void BPTree::removeKey(int x) {


### PR DESCRIPTION
In this commit I've removed the `filesystem` header line from *B+Tree.cpp* and *B+Tree.h*, as I've noticed that we are not using any of the header's classes or functions in our code. This **increases the speed of execution** due to less linking.

Moreover I've added header `cstring` in *remove.cpp* to parse `strcpy` later on in the same file on line 59 or 60.

The development environment used is *Windows 10 with g++ (MinGW.org GCC-6.3.0-1) 6.3.0*.